### PR TITLE
Fix linking with gcc-10

### DIFF
--- a/dpid/dpid.h
+++ b/dpid/dpid.h
@@ -25,10 +25,10 @@
 
 /*! \TODO: Should read this from dillorc */
 #define SRS_NAME "dpid.srs"
-char *srs_name;
+extern char *srs_name;
 
 /*! dpid's service request socket file descriptor */
-int srs_fd;
+extern int srs_fd;
 
 /*! plugin state information
  */
@@ -49,19 +49,19 @@ struct service {
 };
 
 /*! Number of available plugins */
-int numdpis;
+extern int numdpis;
 
 /*! Number of sockets being watched */
-int numsocks;
+extern int numsocks;
 
 /*! State information for each plugin. */
-struct dp *dpi_attr_list;
+extern struct dp *dpi_attr_list;
 
 /*! service served for each plugin  */
-Dlist *services_list;
+extern Dlist *services_list;
 
 /*! Set of sockets watched for connections */
-fd_set sock_set;
+extern fd_set sock_set;
 
 /*! Set to 1 by the SIGCHLD handler dpi_sigchld */
 extern volatile sig_atomic_t caught_sigchld;

--- a/dpid/dpid_common.h
+++ b/dpid/dpid_common.h
@@ -37,10 +37,7 @@
 
 
 /*! Error codes for dpid */
-enum {
-   no_errors,
-   dpid_srs_addrinuse /* dpid service request socket address already in use */
-} dpi_errno;
+extern enum dpi_errno;
 
 /*! Intended for identifying dillo plugins
  * and related files

--- a/dpid/main.c
+++ b/dpid/main.c
@@ -31,6 +31,17 @@
 #include "../dpip/dpip.h"
 
 sigset_t mask_sigchld;
+char *srs_name;
+int srs_fd;
+int numdpis;
+int numsocks;
+struct dp *dpi_attr_list;
+Dlist *services_list;
+fd_set sock_set;
+enum {
+   no_errors,
+   dpid_srs_addrinuse /* dpid service request socket address already in use */
+} dpi_errno;
 
 
 /* Start a dpi filter plugin after accepting the pending connection


### PR DESCRIPTION
Fix #5 (multiple definition linking failure)

Applying patch from https://sources.debian.org/patches/dillo/3.0.5-7/fix-FTBFS-with-gcc-10.patch/ (@xtaran)  
also from https://github.com/dillo-browser/dillo/commit/4d35673f69d837db894305f3b3b618a26d0277c7 (@rodarima, @walley)